### PR TITLE
Fix document download with integer values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 logs/*
 settings_local.py
 *~
+.idea/*
 .Rproj.user
 BasicBrowser/queries/*
 BasicBrowser/static/*

--- a/BasicBrowser/scoping/views.py
+++ b/BasicBrowser/scoping/views.py
@@ -4475,9 +4475,9 @@ def sortdocs(request):
         # work out total relevance
         if "docproject__relevant" in fields:
             dp = DocProject.objects.get(
-                project=query.project,doc=d['pk']
+                project=query.project, doc=d['pk']
             )
-            d['docproject__relevant'] = dp.get_relevant_display() + " ({}) ".format(dp.relevant)
+            d['docproject__relevant'] = f"{dp.get_relevant_display()} ({dp.relevant})"
         if "docfile__id" in fields:
             if d['docfile__id']:
                 d['docfile__id'] = '<a href="/scoping/download_pdf/'+str(d['docfile__id'])+'"">PDF'


### PR DESCRIPTION
Should fix the bug when downloading data that includes integer values

```
Internal Server Error: /scoping/sort_docs

TypeError at /scoping/sort_docs
unsupported operand type(s) for +: 'int' and 'str'

```